### PR TITLE
Dpr2 1912 Fix race condition, refactor the code and add tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ workflows:
           notify_jira: true
           notify_slack: true
           channel: dpr_cicd_alerts
-          command: clean jar shadowJar # Skip tests when building jar, they've already run
+          command: clean jar shadowJar --refresh-dependencies # Skip tests when building jar, they've already run
           filters:
             branches:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ workflows:
           notify_jira: true
           notify_slack: true
           channel: dpr_cicd_alerts
-          command: clean jar shadowJar # Skip tests when building jar, they've already run
+          command: clean jar shadowJar --debug # Skip tests when building jar, they've already run
           filters:
             branches:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ workflows:
           notify_jira: true
           notify_slack: true
           channel: dpr_cicd_alerts
-          command: clean jar shadowJar --debug # Skip tests when building jar, they've already run
+          command: clean jar shadowJar # Skip tests when building jar, they've already run
           filters:
             branches:
               only: /.*/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 plugins {
   kotlin("jvm") version "2.0.21"
   id("jacoco")
-  id("com.github.johnrengelman.shadow") version "8.0.0"
+  id("com.github.johnrengelman.shadow") version "8.1.1"
   id("org.barfuin.gradle.jacocolog") version "3.1.0"
   id("org.owasp.dependencycheck")  version "8.2.1"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,8 @@ dependencies {
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.1")
   testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.1")
   testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.1")
+  testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
+  testImplementation("org.mockito:mockito-core:5.18.0")
 }
 java {
   toolchain.languageVersion.set(JavaLanguageVersion.of(21))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 plugins {
   kotlin("jvm") version "2.0.21"
   id("jacoco")
-  id("com.github.johnrengelman.shadow") version "8.1.1"
+  id("com.github.johnrengelman.shadow") version "8.0.0"
   id("org.barfuin.gradle.jacocolog") version "3.1.0"
   id("org.owasp.dependencycheck")  version "8.2.1"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/Env.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/Env.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.multiphasequery
+
+open class Env {
+    open fun get(name: String): String? = System.getenv(name)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueries.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueries.kt
@@ -17,7 +17,9 @@ class ManageAthenaAsyncQueries : RequestHandler<MutableMap<String, Any>, String>
     private val redshiftClient: RedshiftDataClient = RedshiftDataClient.builder()
         .region(Region.EU_WEST_2)
         .build()
-
+    private val athenaClient: AthenaClient = AthenaClient.builder()
+        .region(Region.EU_WEST_2)
+        .build()
 
     override fun handleRequest(payload: MutableMap<String, Any>, context: Context?): String {
         if (context != null) {
@@ -82,12 +84,6 @@ class ManageAthenaAsyncQueries : RequestHandler<MutableMap<String, Any>, String>
     }
 
     private fun queryRedshift(query:String, logger: LambdaLogger): String {
-        val statementRequest = ExecuteStatementRequest.builder()
-            .clusterIdentifier(System.getenv("CLUSTER_ID"))
-            .database(System.getenv("DB_NAME"))
-            .secretArn(System.getenv("CREDENTIAL_SECRET_ARN"))
-            .sql(query)
-            .build()
 //        parameters?.let {
 //            val idParam = SqlParameter.builder()
 //                .name(it)
@@ -142,9 +138,6 @@ class ManageAthenaAsyncQueries : RequestHandler<MutableMap<String, Any>, String>
     }
 
     private fun queryAthena(query:String, database: String, catalog: String, logger: LambdaLogger): String {
-        val athenaClient: AthenaClient = AthenaClient.builder()
-            .region(Region.EU_WEST_2)
-            .build()
 //              val database = "DIGITAL_PRISON_REPORTING"
 //              val catalog = "nomis"
 //              val query = "SELECT agy_loc_id FROM OMS_OWNER.LIVING_UNITS limit 10;"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueries.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueries.kt
@@ -10,6 +10,8 @@ import software.amazon.awssdk.services.athena.model.QueryExecutionContext
 import software.amazon.awssdk.services.athena.model.StartQueryExecutionRequest
 import software.amazon.awssdk.services.redshiftdata.RedshiftDataClient
 import software.amazon.awssdk.services.redshiftdata.model.*
+import java.sql.Timestamp
+import java.time.Instant
 import java.util.Base64
 
 
@@ -28,13 +30,14 @@ class ManageAthenaAsyncQueries : RequestHandler<MutableMap<String, Any>, String>
             logger.log("Received event $payload", LogLevel.INFO)
             val queryExecutionId = (payload["detail"] as Map<String,Any>)?.get("queryExecutionId") as String
             val currentState = (payload["detail"] as Map<String,Any>)?.get("currentState") as String?
+            val sequenceNumber = (payload["detail"] as Map<String,Any>)?.get("sequenceNumber") as Int
             logger.log("Current state: $currentState", LogLevel.INFO)
             logger.log("Current executionId: $queryExecutionId", LogLevel.INFO)
             if (queryExecutionId == null || currentState == null) {
                 logger.log("No execution ID or current state found in the Event.", LogLevel.ERROR)
                 throw RuntimeException("No execution ID or current state found in the Event.")
             }
-            val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_state = '$currentState' WHERE current_execution_id = '$queryExecutionId'"
+            val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_state = '$currentState', sequence_number = '$sequenceNumber', last_update = ${Timestamp.from(Instant.now())} WHERE current_execution_id = '$queryExecutionId'"
             if (currentState == "SUCCEEDED") {
                 queryRedshift(updateStateQuery, logger)
                 val nextQueryToRun = """
@@ -65,7 +68,7 @@ class ManageAthenaAsyncQueries : RequestHandler<MutableMap<String, Any>, String>
                         val catalog = getData("catalog", 0, getStatementResultResponse)
                         logger.log("The catalog from the admin table is: $catalog", LogLevel.INFO)
                         val athenaExecutionId = queryAthena(query, database, catalog, logger)
-                        val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_execution_id = '$athenaExecutionId' WHERE root_execution_id = '$rootExecutionId' AND index = $index"
+                        val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_execution_id = '$athenaExecutionId', sequence_number = '$sequenceNumber', last_update = ${Timestamp.from(Instant.now())} WHERE root_execution_id = '$rootExecutionId' AND index = $index"
                         queryRedshift(updateStateQuery, logger)
                         return athenaExecutionId
                     }
@@ -74,7 +77,7 @@ class ManageAthenaAsyncQueries : RequestHandler<MutableMap<String, Any>, String>
             } else if (currentState == "FAILED") {
                 val error = ((payload["detail"] as Map<String,Any>)["athenaError"] as Map<String,Any>)["errorMessage"] as String
                 logger.log("Query with execution ID: $queryExecutionId failed. Error: $error",LogLevel.ERROR)
-                val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_state = '$currentState', error = '${Base64.getEncoder().encodeToString(error.toByteArray())}'  WHERE current_execution_id = '$queryExecutionId'"
+                val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_state = '$currentState', error = '${Base64.getEncoder().encodeToString(error.toByteArray())}', sequence_number = '$sequenceNumber', last_update = ${Timestamp.from(Instant.now())}  WHERE current_execution_id = '$queryExecutionId'"
                 queryRedshift(updateStateQuery, logger)
             } else {
                 queryRedshift(updateStateQuery, logger)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueries.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueries.kt
@@ -113,6 +113,7 @@ class ManageAthenaAsyncQueries : RequestHandler<MutableMap<String, Any>, String>
             }
         }
         while (describeStatementResponse.status() != StatusString.FINISHED)
+        logger.log("Finished executing statement with id: $executionId, status: ${describeStatementResponse.statusAsString()}", LogLevel.DEBUG)
         return executionId
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueries.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueries.kt
@@ -37,7 +37,7 @@ class ManageAthenaAsyncQueries : RequestHandler<MutableMap<String, Any>, String>
                 logger.log("No execution ID or current state found in the Event.", LogLevel.ERROR)
                 throw RuntimeException("No execution ID or current state found in the Event.")
             }
-            val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_state = '$currentState', sequence_number = '$sequenceNumber', last_update = ${Timestamp.from(Instant.now())} WHERE current_execution_id = '$queryExecutionId'"
+            val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_state = '$currentState', sequence_number = '$sequenceNumber', last_update = '${Instant.now()}' WHERE current_execution_id = '$queryExecutionId'"
             if (currentState == "SUCCEEDED") {
                 queryRedshift(updateStateQuery, logger)
                 val nextQueryToRun = """
@@ -68,7 +68,7 @@ class ManageAthenaAsyncQueries : RequestHandler<MutableMap<String, Any>, String>
                         val catalog = getData("catalog", 0, getStatementResultResponse)
                         logger.log("The catalog from the admin table is: $catalog", LogLevel.INFO)
                         val athenaExecutionId = queryAthena(query, database, catalog, logger)
-                        val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_execution_id = '$athenaExecutionId', sequence_number = '$sequenceNumber', last_update = ${Timestamp.from(Instant.now())} WHERE root_execution_id = '$rootExecutionId' AND index = $index"
+                        val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_execution_id = '$athenaExecutionId', sequence_number = '$sequenceNumber', last_update = '${Instant.now()}' WHERE root_execution_id = '$rootExecutionId' AND index = $index"
                         queryRedshift(updateStateQuery, logger)
                         return athenaExecutionId
                     }
@@ -77,7 +77,7 @@ class ManageAthenaAsyncQueries : RequestHandler<MutableMap<String, Any>, String>
             } else if (currentState == "FAILED") {
                 val error = ((payload["detail"] as Map<String,Any>)["athenaError"] as Map<String,Any>)["errorMessage"] as String
                 logger.log("Query with execution ID: $queryExecutionId failed. Error: $error",LogLevel.ERROR)
-                val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_state = '$currentState', error = '${Base64.getEncoder().encodeToString(error.toByteArray())}', sequence_number = '$sequenceNumber', last_update = ${Timestamp.from(Instant.now())}  WHERE current_execution_id = '$queryExecutionId'"
+                val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_state = '$currentState', error = '${Base64.getEncoder().encodeToString(error.toByteArray())}', sequence_number = '$sequenceNumber', last_update = '${Instant.now()}'  WHERE current_execution_id = '$queryExecutionId'"
                 queryRedshift(updateStateQuery, logger)
             } else {
                 queryRedshift(updateStateQuery, logger)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueries.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueries.kt
@@ -84,6 +84,12 @@ class ManageAthenaAsyncQueries : RequestHandler<MutableMap<String, Any>, String>
     }
 
     private fun queryRedshift(query:String, logger: LambdaLogger): String {
+        val statementRequest = ExecuteStatementRequest.builder()
+            .clusterIdentifier(System.getenv("CLUSTER_ID"))
+            .database(System.getenv("DB_NAME"))
+            .secretArn(System.getenv("CREDENTIAL_SECRET_ARN"))
+            .sql(query)
+            .build()
 //        parameters?.let {
 //            val idParam = SqlParameter.builder()
 //                .name(it)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueries.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueries.kt
@@ -30,7 +30,7 @@ class ManageAthenaAsyncQueries : RequestHandler<MutableMap<String, Any>, String>
             logger.log("Received event $payload", LogLevel.INFO)
             val queryExecutionId = (payload["detail"] as Map<String,Any>)?.get("queryExecutionId") as String
             val currentState = (payload["detail"] as Map<String,Any>)?.get("currentState") as String?
-            val sequenceNumber = (payload["detail"] as Map<String,Any>)?.get("sequenceNumber") as Int
+            val sequenceNumber = ((payload["detail"] as Map<String,Any>)?.get("sequenceNumber") as String).toInt()
             logger.log("Current state: $currentState", LogLevel.INFO)
             logger.log("Current executionId: $queryExecutionId", LogLevel.INFO)
             if (queryExecutionId == null || currentState == null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueries.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueries.kt
@@ -95,6 +95,7 @@ class ManageAthenaAsyncQueries : RequestHandler<MutableMap<String, Any>, String>
 //                .build()
 //        }
         val executionId = redshiftClient.executeStatement(statementRequest).id()
+        logger.log("Executing admin table query: $query", LogLevel.DEBUG)
         logger.log("Executed admin table statement and got ID: $executionId", LogLevel.DEBUG)
         val describeStatementRequest = DescribeStatementRequest.builder()
             .id(executionId)
@@ -113,7 +114,7 @@ class ManageAthenaAsyncQueries : RequestHandler<MutableMap<String, Any>, String>
             }
         }
         while (describeStatementResponse.status() != StatusString.FINISHED)
-        logger.log("Finished executing statement with id: $executionId, status: ${describeStatementResponse.statusAsString()}", LogLevel.DEBUG)
+        logger.log("Finished executing statement with id: $executionId, status: ${describeStatementResponse.statusAsString()}, result rows: ${describeStatementResponse.resultRows()}", LogLevel.DEBUG)
         return executionId
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryService.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.multiphasequery
+
+import com.amazonaws.services.lambda.runtime.LambdaLogger
+import com.amazonaws.services.lambda.runtime.logging.LogLevel
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.athena.AthenaClient
+import software.amazon.awssdk.services.redshiftdata.RedshiftDataClient
+import uk.gov.justice.digital.hmpps.multiphasequery.data.AthenaRepository
+import uk.gov.justice.digital.hmpps.multiphasequery.data.RedshiftRepository
+
+class MultiphaseQueryService(
+    private val athenaRepository: AthenaRepository,
+    private val redshiftRepository: RedshiftRepository
+) {
+
+    fun updateStateAndMaybeExecuteNext(currentState: String, queryExecutionId: String, sequenceNumber: Int, logger: LambdaLogger, error: String? = null): String? {
+        when (currentState) {
+            "SUCCEEDED" -> {
+                redshiftRepository.updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger)
+                val nextQueryToRun = redshiftRepository.findNextQueryToExecute(queryExecutionId, logger)
+                nextQueryToRun?.let {
+                    val athenaExecutionId = athenaRepository.executeQuery(it.nextQueryToRun, it.database, it.catalog, logger)
+                    redshiftRepository.updateWithNewExecutionId(athenaExecutionId, sequenceNumber, it.rootExecutionId, it.index, logger)
+                    return athenaExecutionId
+                }
+                logger.log("All queries succeeded. No further queries to run.")
+            }
+            "FAILED" -> {
+//                    val error = ((payload["detail"] as Map<String,Any>)["athenaError"] as Map<String,Any>)["errorMessage"] as String
+                logger.log("Query with execution ID: $queryExecutionId failed. Error: $error", LogLevel.ERROR)
+                redshiftRepository.updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger, error)
+                return null
+            }
+            else -> {
+                redshiftRepository.updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger)
+                return null
+            }
+        }
+        return null
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryService.kt
@@ -2,9 +2,6 @@ package uk.gov.justice.digital.hmpps.multiphasequery
 
 import com.amazonaws.services.lambda.runtime.LambdaLogger
 import com.amazonaws.services.lambda.runtime.logging.LogLevel
-import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.athena.AthenaClient
-import software.amazon.awssdk.services.redshiftdata.RedshiftDataClient
 import uk.gov.justice.digital.hmpps.multiphasequery.data.AthenaRepository
 import uk.gov.justice.digital.hmpps.multiphasequery.data.RedshiftRepository
 
@@ -20,7 +17,7 @@ class MultiphaseQueryService(
                 val nextQueryToRun = redshiftRepository.findNextQueryToExecute(queryExecutionId, logger)
                 nextQueryToRun?.let {
                     val athenaExecutionId = athenaRepository.executeQuery(it.nextQueryToRun, it.database, it.catalog, logger)
-                    redshiftRepository.updateWithNewExecutionId(athenaExecutionId, sequenceNumber, it.rootExecutionId, it.index, logger)
+                    redshiftRepository.updateWithNewExecutionId(athenaExecutionId, it.rootExecutionId, it.index, logger)
                     return athenaExecutionId
                 }
                 logger.log("All queries succeeded. No further queries to run.")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/AthenaRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/AthenaRepository.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.multiphasequery.data
+
+import com.amazonaws.services.lambda.runtime.LambdaLogger
+import com.amazonaws.services.lambda.runtime.logging.LogLevel
+import software.amazon.awssdk.services.athena.AthenaClient
+import software.amazon.awssdk.services.athena.model.QueryExecutionContext
+import software.amazon.awssdk.services.athena.model.StartQueryExecutionRequest
+
+class AthenaRepository(private val athenaClient: AthenaClient) {
+
+    fun executeQuery(query:String, database: String, catalog: String, logger: LambdaLogger): String {
+        val queryExecutionContext = QueryExecutionContext.builder()
+            .database(database)
+            .catalog(catalog)
+            .build()
+        val startQueryExecutionRequest = StartQueryExecutionRequest.builder()
+            .queryString(query)
+            .queryExecutionContext(queryExecutionContext)
+            .workGroup("dpr-generic-athena-workgroup")
+            .build()
+        logger.log("Full Athena async query: $query", LogLevel.INFO)
+        val queryExecutionId = athenaClient
+            .startQueryExecution(startQueryExecutionRequest).queryExecutionId()
+        logger.log("Athena Query execution ID: $queryExecutionId", LogLevel.INFO)
+        return queryExecutionId
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/NextQuery.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/NextQuery.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.multiphasequery.data
+
+data class NextQuery(
+    val catalog: String,
+    val database: String,
+    val datasource: String? = null,
+    val index: Int,
+    val rootExecutionId: String,
+    val nextQueryToRun: String,
+) {
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/RedshiftRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/RedshiftRepository.kt
@@ -45,12 +45,12 @@ class RedshiftRepository(private val redshiftClient: RedshiftDataClient) {
         error: String? = null
     ) {
         val maybeError = error?.let{"error = '${Base64.getEncoder().encodeToString(error.toByteArray())}',"} ?: ""
-        val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_state = '$currentState', $maybeError sequence_number = '$sequenceNumber', last_update = '${Instant.now()}' WHERE current_execution_id = '$queryExecutionId'"
+        val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_state = '$currentState', $maybeError sequence_number = $sequenceNumber, last_update = '${Instant.now()}' WHERE current_execution_id = '$queryExecutionId' AND sequence_number < $sequenceNumber"
         executeQueryAndWaitForCompletion(updateStateQuery, logger)
     }
 
     fun updateWithNewExecutionId(athenaExecutionId: String, sequenceNumber: Int, rootExecutionId: String, index: Int, logger: LambdaLogger) {
-        val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_execution_id = '$athenaExecutionId', sequence_number = '$sequenceNumber', last_update = '${Instant.now()}' WHERE root_execution_id = '${rootExecutionId}' AND index = $index"
+        val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_execution_id = '$athenaExecutionId', sequence_number = $sequenceNumber, last_update = '${Instant.now()}' WHERE root_execution_id = '${rootExecutionId}' AND index = $index"
         executeQueryAndWaitForCompletion(updateStateQuery, logger)
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/RedshiftRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/RedshiftRepository.kt
@@ -45,12 +45,13 @@ class RedshiftRepository(private val redshiftClient: RedshiftDataClient) {
         error: String? = null
     ) {
         val maybeError = error?.let{"error = '${Base64.getEncoder().encodeToString(error.toByteArray())}',"} ?: ""
+        //Update the current state only if the sequence number of the Athena State Change event is greater than the existing sequence number stored in Redshift. i.e. only if this is a next event in the sequence.
         val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_state = '$currentState', $maybeError sequence_number = $sequenceNumber, last_update = '${Instant.now()}' WHERE current_execution_id = '$queryExecutionId' AND sequence_number < $sequenceNumber"
         executeQueryAndWaitForCompletion(updateStateQuery, logger)
     }
 
-    fun updateWithNewExecutionId(athenaExecutionId: String, sequenceNumber: Int, rootExecutionId: String, index: Int, logger: LambdaLogger) {
-        val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_execution_id = '$athenaExecutionId', sequence_number = $sequenceNumber, last_update = '${Instant.now()}' WHERE root_execution_id = '${rootExecutionId}' AND index = $index"
+    fun updateWithNewExecutionId(athenaExecutionId: String, rootExecutionId: String, index: Int, logger: LambdaLogger) {
+        val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_execution_id = '$athenaExecutionId', last_update = '${Instant.now()}' WHERE root_execution_id = '${rootExecutionId}' AND index = $index"
         executeQueryAndWaitForCompletion(updateStateQuery, logger)
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/RedshiftRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/RedshiftRepository.kt
@@ -1,0 +1,116 @@
+package uk.gov.justice.digital.hmpps.multiphasequery.data
+
+import com.amazonaws.services.lambda.runtime.LambdaLogger
+import com.amazonaws.services.lambda.runtime.logging.LogLevel
+import software.amazon.awssdk.services.redshiftdata.RedshiftDataClient
+import software.amazon.awssdk.services.redshiftdata.model.*
+import java.time.Instant
+import java.util.Base64
+
+class RedshiftRepository(private val redshiftClient: RedshiftDataClient) {
+
+    fun findNextQueryToExecute(queryExecutionId: String, logger: LambdaLogger): NextQuery? {
+        val queryToFindNextQueryToRun = """
+                 SELECT t2.query, t2.database, t2.catalog, t2.datasource, t2.root_execution_id, t2.index FROM
+                  (SELECT root_execution_id, query, index FROM datamart.admin.execution_manager WHERE current_execution_id = '$queryExecutionId') AS t1
+                  JOIN
+                  (SELECT root_execution_id, index, query, database, catalog, datasource  FROM datamart.admin.execution_manager) AS t2
+                 ON t1.root_execution_id = t2.root_execution_id AND t2.index = (t1.index + 1)
+                  """
+        logger.log("Running admin query to find next query to run", LogLevel.DEBUG)
+        val getStatementResultResponse = queryAndGetResult(queryToFindNextQueryToRun, logger)
+        logger.log("Retrieved ${getStatementResultResponse.totalNumRows()} results from admin table.", LogLevel.DEBUG)
+        return if (getStatementResultResponse.totalNumRows() == 1L) {
+            logger.log("There is a next query to run.", LogLevel.DEBUG)
+            val nextQuery = NextQuery(
+                catalog = getData("catalog", 0, getStatementResultResponse),
+                database = getData("database", 0, getStatementResultResponse),
+                datasource = getData("datasource", 0, getStatementResultResponse),
+                index = getIntData("index", 0, getStatementResultResponse),
+                rootExecutionId = getData("root_execution_id", 0, getStatementResultResponse),
+                nextQueryToRun = String(Base64.getDecoder().decode(getData("query", 0, getStatementResultResponse).removeSurrounding("\"").toByteArray()))
+            )
+            logger.log("Next Query is: $nextQuery", LogLevel.DEBUG)
+            return nextQuery
+        } else {
+            null
+        }
+    }
+
+    fun updateStateOfExistingExecution(
+        currentState: String,
+        sequenceNumber: Int,
+        queryExecutionId: String,
+        logger: LambdaLogger,
+        error: String? = null
+    ) {
+        val maybeError = error?.let{"error = '${Base64.getEncoder().encodeToString(error.toByteArray())}',"} ?: ""
+        val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_state = '$currentState', $maybeError sequence_number = '$sequenceNumber', last_update = '${Instant.now()}' WHERE current_execution_id = '$queryExecutionId'"
+        executeQueryAndWaitForCompletion(updateStateQuery, logger)
+    }
+
+    fun updateWithNewExecutionId(athenaExecutionId: String, sequenceNumber: Int, rootExecutionId: String, index: Int, logger: LambdaLogger) {
+        val updateStateQuery = "UPDATE datamart.admin.execution_manager SET current_execution_id = '$athenaExecutionId', sequence_number = '$sequenceNumber', last_update = '${Instant.now()}' WHERE root_execution_id = '${rootExecutionId}' AND index = $index"
+        executeQueryAndWaitForCompletion(updateStateQuery, logger)
+    }
+
+    private fun queryAndGetResult(query: String, logger: LambdaLogger): GetStatementResultResponse {
+        return getStatementResult(executeQueryAndWaitForCompletion(query, logger))
+    }
+
+    private fun executeQueryAndWaitForCompletion(query:String, logger: LambdaLogger): String {
+        val statementRequest = ExecuteStatementRequest.builder()
+            .clusterIdentifier(System.getenv("CLUSTER_ID"))
+            .database(System.getenv("DB_NAME"))
+            .secretArn(System.getenv("CREDENTIAL_SECRET_ARN"))
+            .sql(query)
+            .build()
+//        parameters?.let {
+//            val idParam = SqlParameter.builder()
+//                .name(it)
+//                .value(it[])
+//                .build()
+//        }
+        val executionId = redshiftClient.executeStatement(statementRequest).id()
+        logger.log("Executing admin table query: $query", LogLevel.DEBUG)
+        logger.log("Executed admin table statement and got ID: $executionId", LogLevel.DEBUG)
+        val describeStatementRequest = DescribeStatementRequest.builder()
+            .id(executionId)
+            .build()
+        var describeStatementResponse: DescribeStatementResponse
+        do {
+            Thread.sleep(500)
+            describeStatementResponse = redshiftClient.describeStatement(describeStatementRequest)
+            if (describeStatementResponse.status() == StatusString.FAILED) {
+                logger.log("Statement with execution ID: $executionId failed with the following error: ${describeStatementResponse.error()}",
+                    LogLevel.ERROR)
+                throw RuntimeException("Statement with execution ID: $executionId failed.")
+            } else if (describeStatementResponse.status() == StatusString.ABORTED) {
+                logger.log("Statement with execution ID: $executionId was aborted", LogLevel.ERROR)
+                throw RuntimeException("Statement with execution ID: $executionId was aborted.")
+            }
+        }
+        while (describeStatementResponse.status() != StatusString.FINISHED)
+        logger.log("Finished executing statement with id: $executionId, status: ${describeStatementResponse.statusAsString()}, result rows: ${describeStatementResponse.resultRows()}", LogLevel.DEBUG)
+        return executionId
+    }
+
+    private fun getStatementResult(executionId: String): GetStatementResultResponse {
+        val getStatementResultRequest = GetStatementResultRequest.builder()
+            .id(executionId)
+            .build()
+        return redshiftClient.getStatementResult(getStatementResultRequest)
+    }
+
+    private fun getData(columnName: String, rowNumber: Int, getStatementResultResponse: GetStatementResultResponse): String {
+        val columnNameToResultIndex = mutableMapOf<String, Int>()
+        getStatementResultResponse.columnMetadata().forEachIndexed{ i, colMetaData -> columnNameToResultIndex[colMetaData.name()] = i}
+        return getStatementResultResponse.records()[rowNumber][columnNameToResultIndex[columnName]!!].stringValue()
+    }
+
+    private fun getIntData(columnName: String, rowNumber: Int, getStatementResultResponse: GetStatementResultResponse): Int {
+        val columnNameToResultIndex = mutableMapOf<String, Int>()
+        getStatementResultResponse.columnMetadata().forEachIndexed{ i, colMetaData -> columnNameToResultIndex[colMetaData.name()] = i}
+        return getStatementResultResponse.records()[rowNumber][columnNameToResultIndex[columnName]!!].longValue().toInt()
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/RedshiftRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/RedshiftRepository.kt
@@ -72,8 +72,8 @@ class RedshiftRepository(private val redshiftClient: RedshiftDataClient) {
 //                .value(it[])
 //                .build()
 //        }
-        val executionId = redshiftClient.executeStatement(statementRequest).id()
         logger.log("Executing admin table query: $query", LogLevel.DEBUG)
+        val executionId = redshiftClient.executeStatement(statementRequest).id()
         logger.log("Executed admin table statement and got ID: $executionId", LogLevel.DEBUG)
         val describeStatementRequest = DescribeStatementRequest.builder()
             .id(executionId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/FakeEnv.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/FakeEnv.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.multiphasequery
+
+import uk.gov.justice.digital.hmpps.multiphasequery.data.REDSHIFT_CLUSTER_ID
+import uk.gov.justice.digital.hmpps.multiphasequery.data.REDSHIFT_CREDENTIAL_SECRET_ARN
+import uk.gov.justice.digital.hmpps.multiphasequery.data.REDSHIFT_DB_NAME
+import uk.gov.justice.digital.hmpps.multiphasequery.data.REDSHIFT_STATUS_POLLING_WAIT_MS
+
+const val REDSHIFT_CLUSTER_ID_VALUE = "REDSHIFT_CLUSTER_ID"
+const val REDSHIFT_DB_NAME_VALUE = "REDSHIFT_DB_NAME"
+const val REDSHIFT_CREDENTIAL_SECRET_ARN_VALUE = "REDSHIFT_CREDENTIAL_SECRET_ARN"
+
+class FakeEnv(
+    private val properties: Map<String, String> = mapOf(
+        RETRY_TIMES to "2",
+        RETRY_DELAY to "0",
+        REDSHIFT_STATUS_POLLING_WAIT_MS to "0",
+        REDSHIFT_CLUSTER_ID to REDSHIFT_CLUSTER_ID_VALUE,
+        REDSHIFT_DB_NAME to REDSHIFT_DB_NAME_VALUE,
+        REDSHIFT_CREDENTIAL_SECRET_ARN to REDSHIFT_CREDENTIAL_SECRET_ARN_VALUE,
+    )
+): Env() {
+
+    override fun get(name: String): String? {
+        return properties[name]
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueriesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueriesTest.kt
@@ -1,7 +1,46 @@
 package uk.gov.justice.digital.hmpps.multiphasequery
 
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.LambdaLogger
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import software.amazon.awssdk.services.athena.AthenaClient
+import uk.gov.justice.digital.hmpps.multiphasequery.data.AthenaRepository
+import uk.gov.justice.digital.hmpps.multiphasequery.data.RedshiftRepository
 
 class ManageAthenaAsyncQueriesTest {
 
+    private val multiphaseQueryService: MultiphaseQueryService = mock()
+    private val context: Context = mock()
+    private val logger: LambdaLogger = mock()
+
+    @BeforeEach
+    fun setUp() {
+        whenever(context.logger).thenReturn(logger)
+    }
+
+    @Test
+    fun `handleRequest returns the execution ID of the next query to execute when there is one`() {
+        val manageAthenaAsyncQueries = ManageAthenaAsyncQueries(multiphaseQueryService)
+        val queryExecutionId = "queryExecutionId"
+        val currentState = "RUNNING"
+        val sequenceNumber = 1
+        val nextQueryExecutionId = "nextQueryExecutionId"
+        val payload: MutableMap<String, Any> = mutableMapOf(
+            "detail"  to mutableMapOf(
+                "queryExecutionId" to queryExecutionId,
+                "currentState" to currentState,
+                "sequenceNumber" to "$sequenceNumber"
+            ),
+        )
+        manageAthenaAsyncQueries.handleRequest(payload, context)
+        whenever(multiphaseQueryService.updateStateAndMaybeExecuteNext(any(), any(), any(), any(), any())).thenReturn(nextQueryExecutionId)
+        verify(multiphaseQueryService, times(1)).updateStateAndMaybeExecuteNext(currentState, queryExecutionId, sequenceNumber, logger)
+    }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueriesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/ManageAthenaAsyncQueriesTest.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.multiphasequery
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.LambdaLogger
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -10,15 +10,14 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import software.amazon.awssdk.services.athena.AthenaClient
-import uk.gov.justice.digital.hmpps.multiphasequery.data.AthenaRepository
-import uk.gov.justice.digital.hmpps.multiphasequery.data.RedshiftRepository
+import org.mockito.kotlin.anyOrNull
 
 class ManageAthenaAsyncQueriesTest {
 
     private val multiphaseQueryService: MultiphaseQueryService = mock()
     private val context: Context = mock()
     private val logger: LambdaLogger = mock()
+    private val manageAthenaAsyncQueries = ManageAthenaAsyncQueries(FakeEnv(), multiphaseQueryService)
 
     @BeforeEach
     fun setUp() {
@@ -26,12 +25,10 @@ class ManageAthenaAsyncQueriesTest {
     }
 
     @Test
-    fun `handleRequest returns the execution ID of the next query to execute when there is one`() {
-        val manageAthenaAsyncQueries = ManageAthenaAsyncQueries(multiphaseQueryService)
+    fun `handleRequest returns the number of rows updated`() {
         val queryExecutionId = "queryExecutionId"
-        val currentState = "RUNNING"
+        val currentState = "SUCCEEDED"
         val sequenceNumber = 1
-        val nextQueryExecutionId = "nextQueryExecutionId"
         val payload: MutableMap<String, Any> = mutableMapOf(
             "detail"  to mutableMapOf(
                 "queryExecutionId" to queryExecutionId,
@@ -39,8 +36,26 @@ class ManageAthenaAsyncQueriesTest {
                 "sequenceNumber" to "$sequenceNumber"
             ),
         )
-        manageAthenaAsyncQueries.handleRequest(payload, context)
-        whenever(multiphaseQueryService.updateStateAndMaybeExecuteNext(any(), any(), any(), any(), any())).thenReturn(nextQueryExecutionId)
+        whenever(multiphaseQueryService.updateStateAndMaybeExecuteNext(any(), any(), any(), any(), anyOrNull())).thenReturn(1)
+        val actual = manageAthenaAsyncQueries.handleRequest(payload, context)
         verify(multiphaseQueryService, times(1)).updateStateAndMaybeExecuteNext(currentState, queryExecutionId, sequenceNumber, logger)
+        assertEquals("Completed execution and updated 1 rows.", actual)
+    }
+
+    @Test
+    fun `handleRequest returns context was null if the Lambda Context was null`() {
+        val queryExecutionId = "queryExecutionId"
+        val currentState = "SUCCEEDED"
+        val sequenceNumber = 1
+        val payload: MutableMap<String, Any> = mutableMapOf(
+            "detail"  to mutableMapOf(
+                "queryExecutionId" to queryExecutionId,
+                "currentState" to currentState,
+                "sequenceNumber" to "$sequenceNumber"
+            ),
+        )
+        val actual = manageAthenaAsyncQueries.handleRequest(payload, null)
+        verify(multiphaseQueryService, times(0)).updateStateAndMaybeExecuteNext(any(), any(), any(), any(), anyOrNull())
+        assertEquals("Context was null.", actual)
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryServiceTest.kt
@@ -1,0 +1,127 @@
+package uk.gov.justice.digital.hmpps.multiphasequery
+
+import com.amazonaws.services.lambda.runtime.LambdaLogger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.multiphasequery.data.AthenaRepository
+import uk.gov.justice.digital.hmpps.multiphasequery.data.NextQuery
+import uk.gov.justice.digital.hmpps.multiphasequery.data.RedshiftRepository
+import java.util.UUID
+
+class MultiphaseQueryServiceTest {
+
+    private val athenaRepository = mock<AthenaRepository>()
+    private val redshiftRepository = mock<RedshiftRepository>()
+    private val logger: LambdaLogger = mock()
+    private val multiphaseQueryService = MultiphaseQueryService(athenaRepository, redshiftRepository, FakeEnv())
+
+    @Test
+    fun `when the state is succeeded and there is no next query only the state of the current query gets updated`() {
+        val queryExecutionId = UUID.randomUUID().toString()
+        val sequenceNumber = 1
+        val resultRowNum = RedshiftRepository.ResultRowNum("someId", 1)
+
+        whenever(redshiftRepository.updateStateOfExistingExecution(any(), any(), any(), any(), anyOrNull())).thenReturn(resultRowNum)
+
+        val actual = multiphaseQueryService.updateStateAndMaybeExecuteNext(SUCCEEDED, queryExecutionId, sequenceNumber, logger)
+
+        verify(redshiftRepository, times(1)).updateStateOfExistingExecution(SUCCEEDED, sequenceNumber, queryExecutionId, logger, null)
+        verify(redshiftRepository, times(1)).findNextQueryToExecute(queryExecutionId, logger)
+        verify(redshiftRepository, times(0)).updateWithNewExecutionId(any(), any(), any(), any())
+        assertEquals(1, actual)
+    }
+
+    @Test
+    fun `when the state is succeeded and there is a next query, the state of the current query gets updated and the next query gets updated with its new execution ID`() {
+        val queryExecutionId = UUID.randomUUID().toString()
+        val sequenceNumber = 1
+        val resultRowNum = RedshiftRepository.ResultRowNum("someId", 1)
+        val catalog = "catalog"
+        val database = "db"
+        val datasource = "datasource"
+        val rootExecutionId = "rootId"
+        val nextQueryToRun = "SELECT * FROM a"
+        val nexQueryIndex = 1
+        val nextQuery = NextQuery(catalog, database, datasource, nexQueryIndex, rootExecutionId, nextQueryToRun)
+        val executionIdOfNextQuery = UUID.randomUUID().toString()
+
+        whenever(redshiftRepository.updateStateOfExistingExecution(any(), any(), any(), any(), anyOrNull())).thenReturn(resultRowNum)
+        whenever(redshiftRepository.findNextQueryToExecute(any(), any())).thenReturn(nextQuery)
+        whenever(athenaRepository.executeQuery(any(), any(), any(), any())).thenReturn(executionIdOfNextQuery)
+        whenever(redshiftRepository.updateWithNewExecutionId(any(), any(), any(), any())).thenReturn(1)
+
+        val actual = multiphaseQueryService.updateStateAndMaybeExecuteNext(SUCCEEDED, queryExecutionId, sequenceNumber, logger)
+
+        verify(redshiftRepository, times(1)).updateStateOfExistingExecution(SUCCEEDED, sequenceNumber, queryExecutionId, logger, null)
+        verify(redshiftRepository, times(1)).findNextQueryToExecute(queryExecutionId, logger)
+        verify(athenaRepository, times(1)).executeQuery(nextQueryToRun, database, catalog, logger)
+        verify(redshiftRepository, times(1)).updateWithNewExecutionId(executionIdOfNextQuery, rootExecutionId, nexQueryIndex, logger)
+        assertEquals(2, actual)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = [FAILED, "QUEUED", SUCCEEDED, "RUNNING", "CANCELLED"])
+    fun `updateStateOfExistingExecution should be called for any state`(currentState: String) {
+        val queryExecutionId = UUID.randomUUID().toString()
+        val sequenceNumber = 1
+        val resultRowNum = RedshiftRepository.ResultRowNum("someId", 1)
+        var maybeError: String? = null
+
+        whenever(redshiftRepository.updateStateOfExistingExecution(any(), any(), any(), any(), anyOrNull())).thenReturn(resultRowNum)
+        if (currentState == FAILED) {
+            maybeError = "Error"
+        }
+
+        val actual = multiphaseQueryService.updateStateAndMaybeExecuteNext(currentState, queryExecutionId, sequenceNumber, logger, maybeError)
+
+        verify(redshiftRepository, times(1)).updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger, maybeError)
+        assertEquals(1, actual)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = [FAILED, "QUEUED", SUCCEEDED, "RUNNING", "CANCELLED"])
+    fun `updateStateOfExistingExecution should be retried up to 2 times for any state until it updates the state`(currentState: String) {
+        val queryExecutionId = UUID.randomUUID().toString()
+        val sequenceNumber = 1
+        val resultRowNum = RedshiftRepository.ResultRowNum("someId", 0)
+        var maybeError: String? = null
+
+        whenever(redshiftRepository.updateStateOfExistingExecution(any(), any(), any(), any(), anyOrNull())).thenReturn(resultRowNum)
+        if (currentState == FAILED) {
+            maybeError = "Error"
+        }
+
+        val actual = multiphaseQueryService.updateStateAndMaybeExecuteNext(currentState, queryExecutionId, sequenceNumber, logger, maybeError)
+
+        verify(redshiftRepository, times(3)).updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger, maybeError)
+        assertEquals(0, actual)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = [FAILED, "QUEUED", SUCCEEDED, "RUNNING", "CANCELLED"])
+    fun `updateStateOfExistingExecution should stop retrying when the state gets updated`(currentState: String) {
+        val queryExecutionId = UUID.randomUUID().toString()
+        val sequenceNumber = 1
+        val resultRowNum1 = RedshiftRepository.ResultRowNum("someId", 0)
+        val resultRowNum2 = RedshiftRepository.ResultRowNum("someId", 1)
+        var maybeError: String? = null
+
+        whenever(redshiftRepository.updateStateOfExistingExecution(any(), any(), any(), any(), anyOrNull())).thenReturn(resultRowNum1, resultRowNum2)
+        if (currentState == FAILED) {
+            maybeError = "Error"
+        }
+
+        val actual = multiphaseQueryService.updateStateAndMaybeExecuteNext(currentState, queryExecutionId, sequenceNumber, logger, maybeError)
+
+        verify(redshiftRepository, times(2)).updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger, maybeError)
+        assertEquals(1, actual)
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/AthenaRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/AthenaRepositoryTest.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.hmpps.multiphasequery.data
+
+import com.amazonaws.services.lambda.runtime.LambdaLogger
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import software.amazon.awssdk.services.athena.AthenaClient
+import software.amazon.awssdk.services.athena.model.QueryExecutionContext
+import software.amazon.awssdk.services.athena.model.StartQueryExecutionRequest
+import software.amazon.awssdk.services.athena.model.StartQueryExecutionResponse
+
+class AthenaRepositoryTest {
+    @Test
+    fun `executeQuery should call the athenaClient startQueryExecution with the correct arguments and return the execution ID`() {
+        val athenaClient = mock<AthenaClient>()
+        val startQueryExecutionResponse = mock<StartQueryExecutionResponse>()
+        val athenaRepository = AthenaRepository(athenaClient)
+        val database = "testDb"
+        val catalog = "testCatalog"
+        val query = "SELECT * FROM a"
+        val workgroup = "dpr-generic-athena-workgroup"
+        val executionId = "executionId"
+        val logger = mock<LambdaLogger>()
+        val queryExecutionContext = QueryExecutionContext.builder()
+            .database(database)
+            .catalog(catalog)
+            .build()
+        val startQueryExecutionRequest = StartQueryExecutionRequest.builder()
+            .queryString(
+                query
+            )
+            .queryExecutionContext(queryExecutionContext)
+            .workGroup(workgroup)
+            .build()
+
+        whenever(
+            athenaClient.startQueryExecution(
+                ArgumentMatchers.any(StartQueryExecutionRequest::class.java),
+            ),
+        ).thenReturn(startQueryExecutionResponse)
+        whenever(
+            startQueryExecutionResponse.queryExecutionId(),
+        ).thenReturn(executionId)
+
+        val actual = athenaRepository.executeQuery(query, database, catalog, logger)
+
+        verify(athenaClient, times(1)).startQueryExecution(startQueryExecutionRequest)
+        assertEquals(executionId, actual)
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/RedshiftRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/RedshiftRepositoryTest.kt
@@ -1,0 +1,193 @@
+package uk.gov.justice.digital.hmpps.multiphasequery.data
+
+import com.amazonaws.services.lambda.runtime.LambdaLogger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import software.amazon.awssdk.services.redshiftdata.RedshiftDataClient
+import software.amazon.awssdk.services.redshiftdata.model.*
+import uk.gov.justice.digital.hmpps.multiphasequery.*
+import uk.gov.justice.digital.hmpps.multiphasequery.data.RedshiftRepository.*
+import java.time.Instant
+import java.util.UUID
+
+class RedshiftRepositoryTest {
+
+    private val redshiftDataClient = mock<RedshiftDataClient>()
+    private val redshiftRepository = RedshiftRepository(redshiftDataClient, FakeEnv())
+    private val logger = mock<LambdaLogger>()
+    private val queryExecutionId = "executionId"
+    private val catalog = "someCatalog"
+    private val database = "db"
+    private val datasourceName = "datasourceName"
+    private val rootExecutionId = "someRootExecutionId"
+    private val index = 1L
+    private val selectStatementExecutionId = "selectStatementExecutionId"
+    private val executeStatementResponse = mock<ExecuteStatementResponse>()
+    private val describeStatementResponse = mock<DescribeStatementResponse>()
+
+    @Test
+    fun `findNextQueryToExecute returns the next query if it exists`() {
+        val executeStatementRequest = setUpExecuteStatementRequest(findNextQuerySelectSql())
+        val describeStatementRequest = setUpDescribeStatementRequest(selectStatementExecutionId)
+        val getStatementResultRequest = setUpGetStatementResultRequest(selectStatementExecutionId)
+        val getStatementResultResponse: GetStatementResultResponse = GetStatementResultResponse
+            .builder()
+            .columnMetadata(buildHeaderRow())
+            .records(buildSingleRowResult())
+            .totalNumRows(1)
+            .build()
+
+        whenever(redshiftDataClient.executeStatement(ArgumentMatchers.any(ExecuteStatementRequest::class.java),),).thenReturn(executeStatementResponse)
+        whenever(executeStatementResponse.id()).thenReturn(selectStatementExecutionId)
+        whenever(redshiftDataClient.describeStatement(ArgumentMatchers.any(DescribeStatementRequest::class.java))).thenReturn(describeStatementResponse)
+        whenever(describeStatementResponse.status()).thenReturn(StatusString.FINISHED)
+        whenever(redshiftDataClient.getStatementResult(ArgumentMatchers.any(GetStatementResultRequest::class.java))).thenReturn(getStatementResultResponse)
+
+        val actual = redshiftRepository.findNextQueryToExecute(queryExecutionId, logger)
+
+        verify(redshiftDataClient, times(1)).executeStatement(executeStatementRequest)
+        verify(redshiftDataClient, times(1)).describeStatement(describeStatementRequest)
+        verify(redshiftDataClient, times(1)).getStatementResult(getStatementResultRequest)
+        assertEquals(NextQuery(catalog, database, datasourceName, index.toInt(), rootExecutionId, "SELECT * FROM a"), actual)
+    }
+
+    @Test
+    fun `findNextQueryToExecute returns null if there is no next query`() {
+        val executeStatementRequest = setUpExecuteStatementRequest(findNextQuerySelectSql())
+        val describeStatementRequest = setUpDescribeStatementRequest(selectStatementExecutionId)
+        val getStatementResultRequest = setUpGetStatementResultRequest(selectStatementExecutionId)
+        val getStatementResultResponse: GetStatementResultResponse = GetStatementResultResponse
+            .builder()
+            .columnMetadata(buildHeaderRow())
+            .records(listOf(emptyList()))
+            .totalNumRows(0)
+            .build()
+
+        whenever(redshiftDataClient.executeStatement(ArgumentMatchers.any(ExecuteStatementRequest::class.java),),).thenReturn(executeStatementResponse)
+        whenever(executeStatementResponse.id()).thenReturn(selectStatementExecutionId)
+        whenever(redshiftDataClient.describeStatement(ArgumentMatchers.any(DescribeStatementRequest::class.java))).thenReturn(describeStatementResponse)
+        whenever(describeStatementResponse.status()).thenReturn(StatusString.FINISHED)
+        whenever(redshiftDataClient.getStatementResult(ArgumentMatchers.any(GetStatementResultRequest::class.java))).thenReturn(getStatementResultResponse)
+
+        val actual = redshiftRepository.findNextQueryToExecute(queryExecutionId, logger)
+
+        verify(redshiftDataClient, times(1)).executeStatement(executeStatementRequest)
+        verify(redshiftDataClient, times(1)).describeStatement(describeStatementRequest)
+        verify(redshiftDataClient, times(1)).getStatementResult(getStatementResultRequest)
+        assertNull(actual)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = [SUCCEEDED, FAILED])
+    fun `updateStateOfExistingExecution updates the state and returns the execution ID of the update and the rows updated`(state: String) {
+        val instant = Instant.parse("2025-05-28T06:00:00Z")
+        Mockito.mockStatic(Instant::class.java).use { staticTimestampMockUtil ->
+            staticTimestampMockUtil.`when`<Instant> { Instant.now() }.thenReturn(instant)
+            val updateExecutionId = UUID.randomUUID().toString()
+            val sequenceNumber = 3
+            val maybeError: String? = (if (state == FAILED) "Something went wrong." else null)
+            val executeStatementRequest = setUpExecuteStatementRequest(updateStateOfExistingExecutionSql(state, sequenceNumber, maybeError?.let { "U29tZXRoaW5nIHdlbnQgd3Jvbmcu" }))
+            val describeStatementRequest = setUpDescribeStatementRequest(updateExecutionId)
+
+            whenever(redshiftDataClient.executeStatement(ArgumentMatchers.any(ExecuteStatementRequest::class.java),),).thenReturn(executeStatementResponse)
+            whenever(executeStatementResponse.id()).thenReturn(updateExecutionId)
+            whenever(redshiftDataClient.describeStatement(ArgumentMatchers.any(DescribeStatementRequest::class.java))).thenReturn(describeStatementResponse)
+            whenever(describeStatementResponse.status()).thenReturn(StatusString.FINISHED)
+            whenever(describeStatementResponse.resultRows()).thenReturn(1L)
+
+            val actual = redshiftRepository.updateStateOfExistingExecution(state, sequenceNumber, queryExecutionId, logger, maybeError)
+
+            verify(redshiftDataClient, times(1)).executeStatement(executeStatementRequest)
+            verify(redshiftDataClient, times(1)).describeStatement(describeStatementRequest)
+            assertEquals(ResultRowNum(updateExecutionId,1), actual)
+        }
+    }
+
+    @Test
+    fun `updateWithNewExecutionId updates the matching rootExecution row with the new executionId for that index`() {
+        val instant = Instant.parse("2025-05-28T06:00:00Z")
+        Mockito.mockStatic(Instant::class.java).use { staticTimestampMockUtil ->
+            staticTimestampMockUtil.`when`<Instant> { Instant.now() }.thenReturn(instant)
+            val updateExecutionId = UUID.randomUUID().toString()
+            val executeStatementRequest = setUpExecuteStatementRequest(updateWithNewExecutionIdSql())
+            val describeStatementRequest = setUpDescribeStatementRequest(updateExecutionId)
+            val updatedRows = 1L
+
+            whenever(redshiftDataClient.executeStatement(ArgumentMatchers.any(ExecuteStatementRequest::class.java),),).thenReturn(executeStatementResponse)
+            whenever(executeStatementResponse.id()).thenReturn(updateExecutionId)
+            whenever(redshiftDataClient.describeStatement(ArgumentMatchers.any(DescribeStatementRequest::class.java))).thenReturn(describeStatementResponse)
+            whenever(describeStatementResponse.status()).thenReturn(StatusString.FINISHED)
+            whenever(describeStatementResponse.resultRows()).thenReturn(updatedRows)
+
+            val actual = redshiftRepository.updateWithNewExecutionId(queryExecutionId, rootExecutionId, index.toInt(), logger)
+
+            verify(redshiftDataClient, times(1)).executeStatement(executeStatementRequest)
+            verify(redshiftDataClient, times(1)).describeStatement(describeStatementRequest)
+            assertEquals(updatedRows, actual)
+        }
+    }
+
+    private fun buildSingleRowResult() =
+        listOf(
+            buildRow(listOf(database, catalog, datasourceName, rootExecutionId, "\"U0VMRUNUICogRlJPTSBh\"")).plus(
+                buildIndexField(
+                    index
+                )
+            )
+        )
+
+    private fun setUpGetStatementResultRequest(selectStatementExecutionId: String): GetStatementResultRequest? =
+        GetStatementResultRequest.builder()
+            .id(selectStatementExecutionId)
+            .build()
+
+    private fun setUpDescribeStatementRequest(statementExecutionId: String): DescribeStatementRequest? =
+        DescribeStatementRequest.builder()
+            .id(statementExecutionId)
+            .build()
+
+    private fun setUpExecuteStatementRequest(query: String): ExecuteStatementRequest? =
+        ExecuteStatementRequest.builder()
+            .clusterIdentifier(REDSHIFT_CLUSTER_ID_VALUE)
+            .database(REDSHIFT_DB_NAME_VALUE)
+            .secretArn(REDSHIFT_CREDENTIAL_SECRET_ARN_VALUE)
+            .sql(query)
+            .build()
+
+    private fun findNextQuerySelectSql(): String {
+        return """
+                 SELECT t2.query, t2.database, t2.catalog, t2.datasource, t2.root_execution_id, t2.index FROM
+                  (SELECT root_execution_id, query, index FROM datamart.admin.execution_manager WHERE current_execution_id = '$queryExecutionId') AS t1
+                  JOIN
+                  (SELECT root_execution_id, index, query, database, catalog, datasource  FROM datamart.admin.execution_manager) AS t2
+                 ON t1.root_execution_id = t2.root_execution_id AND t2.index = (t1.index + 1)
+                  """
+    }
+
+    private fun updateStateOfExistingExecutionSql(state: String, sequenceNumber: Int, maybeError: String?): String {
+        return "UPDATE datamart.admin.execution_manager SET current_state = '$state', ${maybeError?.let { "error = '$it'," } ?: ""} sequence_number = $sequenceNumber, last_update = '${Instant.now()}' WHERE current_execution_id = '$queryExecutionId' AND sequence_number < $sequenceNumber"
+    }
+
+    private fun updateWithNewExecutionIdSql(): String {
+        return "UPDATE datamart.admin.execution_manager SET current_execution_id = '$queryExecutionId', last_update = '${Instant.now()}' WHERE root_execution_id = '${rootExecutionId}' AND index = $index"
+    }
+
+    private fun buildHeaderRow(): List<ColumnMetadata>  {
+        return listOf("database", "catalog", "datasource", "root_execution_id", "query", "index").map { ColumnMetadata.builder().name(it).build() }
+    }
+
+    private fun buildRow(columns: List<String>): List<Field> {
+        return columns.map { Field.builder().stringValue(it).build() }
+    }
+
+    private fun buildIndexField(index: Long): Field? = Field.builder().longValue(index).build()
+}


### PR DESCRIPTION
Changes include:
- Fix race condition by using the [event sequence number](https://docs.aws.amazon.com/athena/latest/ug/athena-events.html) to update a state only if it is a next state and not a previous one. This issue has been taking place since EventBridge does not guarantee the order the events are delivered.
- Also use retry mechanism to retry updates up to a configurable amount of times with a configurable back off.
- Refactor the code. Split layers of service and repository.
- Added tests.
- More logging added to log timestamps of when a Redshift query has moved to finished state.
- Added last_update column to capture the timestamp of every update of a query. 