### PR TITLE
DPR2-1920 change table and column names

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/NextQuery.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/NextQuery.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.multiphasequery.data
 data class NextQuery(
     val catalog: String,
     val database: String,
-    val datasource: String? = null,
+    val datasourceName: String? = null,
     val index: Int,
     val rootExecutionId: String,
     val nextQueryToRun: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryServiceTest.kt
@@ -46,11 +46,11 @@ class MultiphaseQueryServiceTest {
         val resultRowNum = RedshiftRepository.ResultRowNum("someId", 1)
         val catalog = "catalog"
         val database = "db"
-        val datasource = "datasource"
+        val datasourceName = "datasourceName"
         val rootExecutionId = "rootId"
         val nextQueryToRun = "SELECT * FROM a"
         val nexQueryIndex = 1
-        val nextQuery = NextQuery(catalog, database, datasource, nexQueryIndex, rootExecutionId, nextQueryToRun)
+        val nextQuery = NextQuery(catalog, database, datasourceName, nexQueryIndex, rootExecutionId, nextQueryToRun)
         val executionIdOfNextQuery = UUID.randomUUID().toString()
 
         whenever(redshiftRepository.updateStateOfExistingExecution(any(), any(), any(), any(), anyOrNull())).thenReturn(resultRowNum)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/RedshiftRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/RedshiftRepositoryTest.kt
@@ -157,24 +157,24 @@ class RedshiftRepositoryTest {
 
     private fun findNextQuerySelectSql(): String {
         return """
-                 SELECT t2.query, t2.database, t2.catalog, t2.datasource, t2.root_execution_id, t2.index FROM
-                  (SELECT root_execution_id, query, index FROM datamart.admin.execution_manager WHERE current_execution_id = '$queryExecutionId') AS t1
+                 SELECT t2.query, t2.database, t2.catalog, t2.datasource_name, t2.root_execution_id, t2.index FROM
+                  (SELECT root_execution_id, query, index FROM datamart.admin.multiphase_query_state WHERE current_execution_id = '$queryExecutionId') AS t1
                   JOIN
-                  (SELECT root_execution_id, index, query, database, catalog, datasource  FROM datamart.admin.execution_manager) AS t2
+                  (SELECT root_execution_id, index, query, database, catalog, datasource_name  FROM datamart.admin.multiphase_query_state) AS t2
                  ON t1.root_execution_id = t2.root_execution_id AND t2.index = (t1.index + 1)
                   """
     }
 
     private fun updateStateOfExistingExecutionSql(state: String, sequenceNumber: Int, maybeError: String?): String {
-        return "UPDATE datamart.admin.execution_manager SET current_state = '$state', ${maybeError?.let { "error = '$it'," } ?: ""} sequence_number = $sequenceNumber, last_update = SYSDATE WHERE current_execution_id = '$queryExecutionId' AND sequence_number < $sequenceNumber"
+        return "UPDATE datamart.admin.multiphase_query_state SET current_state = '$state', ${maybeError?.let { "error = '$it'," } ?: ""} sequence_number = $sequenceNumber, last_update = SYSDATE WHERE current_execution_id = '$queryExecutionId' AND sequence_number < $sequenceNumber"
     }
 
     private fun updateWithNewExecutionIdSql(): String {
-        return "UPDATE datamart.admin.execution_manager SET current_execution_id = '$queryExecutionId', last_update = SYSDATE WHERE root_execution_id = '${rootExecutionId}' AND index = $index"
+        return "UPDATE datamart.admin.multiphase_query_state SET current_execution_id = '$queryExecutionId', last_update = SYSDATE WHERE root_execution_id = '${rootExecutionId}' AND index = $index"
     }
 
     private fun buildHeaderRow(): List<ColumnMetadata>  {
-        return listOf("database", "catalog", "datasource", "root_execution_id", "query", "index").map { ColumnMetadata.builder().name(it).build() }
+        return listOf("database", "catalog", "datasource_name", "root_execution_id", "query", "index").map { ColumnMetadata.builder().name(it).build() }
     }
 
     private fun buildRow(columns: List<String>): List<Field> {


### PR DESCRIPTION
Changed:

- Table name from: `execution_manager` to `multiphase_query_state`
- Column name from `datasource` to `datasource_name`

This is for better naming which describes better the purpose of the table and column.