### PR TITLE
DPR2-2082 handle error and update Redshift table

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryService.kt
@@ -18,25 +18,34 @@ class MultiphaseQueryService(
 ) {
 
     fun updateStateAndMaybeExecuteNext(currentState: String, queryExecutionId: String, sequenceNumber: Int, logger: LambdaLogger, error: String? = null): Long {
-        when (currentState) {
-            SUCCEEDED -> {
-                var resultingRows = retry (logger) {
-                    redshiftRepository.updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger)
+        try {
+            when (currentState) {
+                SUCCEEDED -> {
+                    var resultingRows = retry (logger) {
+                        redshiftRepository.updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger)
+                    }
+                    val nextQueryToRun = redshiftRepository.findNextQueryToExecute(queryExecutionId, logger)
+                    nextQueryToRun?.let {
+                        val athenaExecutionId = athenaRepository.executeQuery(it.nextQueryToRun, it.database, it.catalog, logger)
+                        resultingRows += redshiftRepository.updateWithNewExecutionId(athenaExecutionId, it.rootExecutionId, it.index, logger)
+                    } ?: logger.log("All queries succeeded. No further queries to run.")
+                    return resultingRows
                 }
-                val nextQueryToRun = redshiftRepository.findNextQueryToExecute(queryExecutionId, logger)
-                nextQueryToRun?.let {
-                    val athenaExecutionId = athenaRepository.executeQuery(it.nextQueryToRun, it.database, it.catalog, logger)
-                    resultingRows += redshiftRepository.updateWithNewExecutionId(athenaExecutionId, it.rootExecutionId, it.index, logger)
-                } ?: logger.log("All queries succeeded. No further queries to run.")
-                return resultingRows
+                FAILED -> {
+                    logger.log("Query with execution ID: $queryExecutionId failed. Error: $error", LogLevel.ERROR)
+                    return retry (logger) { redshiftRepository.updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger, error) }
+                }
+                else -> {
+                    return retry (logger) { redshiftRepository.updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger) }
+                }
             }
-            FAILED -> {
-                logger.log("Query with execution ID: $queryExecutionId failed. Error: $error", LogLevel.ERROR)
-                return retry (logger) { redshiftRepository.updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger, error) }
-            }
-            else -> {
-                return retry (logger) { redshiftRepository.updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger) }
-            }
+        } catch (e: Exception) {
+            logger.log("Error executing multiphase query. Error: ${e.message}", LogLevel.ERROR)
+            redshiftRepository.updateStateOfExistingExecution(
+                currentState, sequenceNumber, queryExecutionId, logger, error ?: "Unexpected error."
+            )
+            logger.log("Stored error state in Redshift.", LogLevel.INFO)
+            throw e
         }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryServiceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.multiphasequery
 
 import com.amazonaws.services.lambda.runtime.LambdaLogger
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -11,6 +12,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import software.amazon.awssdk.services.athena.model.InternalServerException
 import uk.gov.justice.digital.hmpps.multiphasequery.data.AthenaRepository
 import uk.gov.justice.digital.hmpps.multiphasequery.data.NextQuery
 import uk.gov.justice.digital.hmpps.multiphasequery.data.RedshiftRepository
@@ -123,5 +125,30 @@ class MultiphaseQueryServiceTest {
 
         verify(redshiftRepository, times(2)).updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger, maybeError)
         assertEquals(1, actual)
+    }
+
+    @Test
+    fun `updateStateOfExistingExecution should be called when there is an exception`() {
+        val currentState = SUCCEEDED
+        val queryExecutionId = UUID.randomUUID().toString()
+        val sequenceNumber = 1
+        val resultRowNum = RedshiftRepository.ResultRowNum("someId", 1)
+        val catalog = "catalog"
+        val database = "db"
+        val datasourceName = "datasourceName"
+        val rootExecutionId = "rootId"
+        val nextQueryToRun = "SELECT * FROM a"
+        val nexQueryIndex = 1
+        val nextQuery = NextQuery(catalog, database, datasourceName, nexQueryIndex, rootExecutionId, nextQueryToRun)
+
+        whenever(redshiftRepository.findNextQueryToExecute(any(), any())).thenReturn(nextQuery)
+        whenever(redshiftRepository.updateStateOfExistingExecution(any(), any(), any(), any(), anyOrNull())).thenReturn(resultRowNum)
+        whenever(athenaRepository.executeQuery(any(), any(), any(), any())).thenThrow(InternalServerException.builder().message("Some network error").build())
+
+        Assertions.assertThrows(InternalServerException::class.java) {
+            multiphaseQueryService.updateStateAndMaybeExecuteNext(currentState, queryExecutionId, sequenceNumber, logger)
+        }
+        verify(redshiftRepository, times(1)).updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger)
+        verify(redshiftRepository, times(1)).updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger)
     }
 }


### PR DESCRIPTION
In some cases the Athena client might throw an error for various reasons before even the query is executed. 
This was not handled with the status was not being updated and as a result the FE kept polling for 15 minutes until eventually marking the query as failed. 
These changes update the status when there is such an error to provide earlier feedback.