### PR TITLE
Dpr2 2082 store error explicitly

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryService.kt
@@ -42,7 +42,7 @@ class MultiphaseQueryService(
         } catch (e: Exception) {
             logger.log("Error executing multiphase query. Error: ${e.message}", LogLevel.ERROR)
             redshiftRepository.updateStateOfExistingExecution(
-                currentState, sequenceNumber, queryExecutionId, logger, error ?: "Unexpected error."
+                FAILED, sequenceNumber, queryExecutionId, logger, error ?: "Unexpected error."
             )
             logger.log("Stored error state in Redshift.", LogLevel.INFO)
             throw e

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryService.kt
@@ -18,34 +18,35 @@ class MultiphaseQueryService(
 ) {
 
     fun updateStateAndMaybeExecuteNext(currentState: String, queryExecutionId: String, sequenceNumber: Int, logger: LambdaLogger, error: String? = null): Long {
-        try {
-            when (currentState) {
-                SUCCEEDED -> {
-                    var resultingRows = retry (logger) {
-                        redshiftRepository.updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger)
-                    }
-                    val nextQueryToRun = redshiftRepository.findNextQueryToExecute(queryExecutionId, logger)
-                    nextQueryToRun?.let {
-                        val athenaExecutionId = athenaRepository.executeQuery(it.nextQueryToRun, it.database, it.catalog, logger)
-                        resultingRows += redshiftRepository.updateWithNewExecutionId(athenaExecutionId, it.rootExecutionId, it.index, logger)
-                    } ?: logger.log("All queries succeeded. No further queries to run.")
-                    return resultingRows
+        when (currentState) {
+            SUCCEEDED -> {
+                var resultingRows = retry (logger) {
+                    redshiftRepository.updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger)
                 }
-                FAILED -> {
-                    logger.log("Query with execution ID: $queryExecutionId failed. Error: $error", LogLevel.ERROR)
-                    return retry (logger) { redshiftRepository.updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger, error) }
-                }
-                else -> {
-                    return retry (logger) { redshiftRepository.updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger) }
-                }
+                val nextQueryToRun = redshiftRepository.findNextQueryToExecute(queryExecutionId, logger)
+                nextQueryToRun?.let {
+                    val athenaExecutionId =
+                        try {
+                            athenaRepository.executeQuery(it.nextQueryToRun, it.database, it.catalog, logger)
+                        } catch (e: Exception) {
+                            logger.log("Error executing next multiphase query. Error: ${e.message}", LogLevel.ERROR)
+                            redshiftRepository.updateNextQueryWithFailedToExecute(
+                                it.rootExecutionId, it.index, "Failed to execute query at index ${it.index}: ${it.nextQueryToRun} Error: ${e.message}", logger,
+                            )
+                            logger.log("Stored error state in Redshift.", LogLevel.INFO)
+                            throw e
+                        }
+                    resultingRows += redshiftRepository.updateWithNewExecutionId(athenaExecutionId, it.rootExecutionId, it.index, logger)
+                } ?: logger.log("All queries succeeded. No further queries to run.")
+                return resultingRows
             }
-        } catch (e: Exception) {
-            logger.log("Error executing multiphase query. Error: ${e.message}", LogLevel.ERROR)
-            redshiftRepository.updateStateOfExistingExecution(
-                FAILED, sequenceNumber, queryExecutionId, logger, error ?: "Unexpected error."
-            )
-            logger.log("Stored error state in Redshift.", LogLevel.INFO)
-            throw e
+            FAILED -> {
+                logger.log("Query with execution ID: $queryExecutionId failed. Error: $error", LogLevel.ERROR)
+                return retry (logger) { redshiftRepository.updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger, error) }
+            }
+            else -> {
+                return retry (logger) { redshiftRepository.updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger) }
+            }
         }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/RedshiftRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/RedshiftRepository.kt
@@ -5,7 +5,7 @@ import com.amazonaws.services.lambda.runtime.logging.LogLevel
 import software.amazon.awssdk.services.redshiftdata.RedshiftDataClient
 import software.amazon.awssdk.services.redshiftdata.model.*
 import uk.gov.justice.digital.hmpps.multiphasequery.Env
-import java.time.Instant
+import uk.gov.justice.digital.hmpps.multiphasequery.FAILED
 import java.util.Base64
 
 const val REDSHIFT_STATUS_POLLING_WAIT_MS = "REDSHIFT_STATUS_POLLING_WAIT_MS"
@@ -59,6 +59,11 @@ class RedshiftRepository(private val redshiftClient: RedshiftDataClient, private
 
     fun updateWithNewExecutionId(athenaExecutionId: String, rootExecutionId: String, index: Int, logger: LambdaLogger): Long {
         val updateStateQuery = "UPDATE datamart.admin.multiphase_query_state SET current_execution_id = '$athenaExecutionId', last_update = SYSDATE WHERE root_execution_id = '${rootExecutionId}' AND index = $index"
+        return executeQueryAndWaitForCompletion(updateStateQuery, logger).resultingRows
+    }
+
+    fun updateNextQueryWithFailedToExecute(rootExecutionId: String, index: Int, error: String, logger: LambdaLogger): Long {
+        val updateStateQuery = "UPDATE datamart.admin.multiphase_query_state SET current_state = '$FAILED', error = '${Base64.getEncoder().encodeToString(error.toByteArray())}', last_update = SYSDATE WHERE root_execution_id = '${rootExecutionId}' AND index = $index"
         return executeQueryAndWaitForCompletion(updateStateQuery, logger).resultingRows
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/MultiphaseQueryServiceTest.kt
@@ -149,6 +149,7 @@ class MultiphaseQueryServiceTest {
             multiphaseQueryService.updateStateAndMaybeExecuteNext(currentState, queryExecutionId, sequenceNumber, logger)
         }
         verify(redshiftRepository, times(1)).updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger)
-        verify(redshiftRepository, times(1)).updateStateOfExistingExecution(currentState, sequenceNumber, queryExecutionId, logger)
+        verify(redshiftRepository, times(1)).updateNextQueryWithFailedToExecute(rootExecutionId, nexQueryIndex, "Failed to execute query at index 1: SELECT * FROM a Error: Some network error", logger)
+        verify(redshiftRepository, times(0)).updateWithNewExecutionId(any(), any(), any(), any())
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/RedshiftRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/multiphasequery/data/RedshiftRepositoryTest.kt
@@ -17,6 +17,7 @@ import software.amazon.awssdk.services.redshiftdata.model.*
 import uk.gov.justice.digital.hmpps.multiphasequery.*
 import uk.gov.justice.digital.hmpps.multiphasequery.data.RedshiftRepository.*
 import java.time.Instant
+import java.util.Base64
 import java.util.UUID
 
 class RedshiftRepositoryTest {
@@ -128,6 +129,26 @@ class RedshiftRepositoryTest {
         assertEquals(updatedRows, actual)
     }
 
+    @Test
+    fun `updateNextQueryWithFailedToExecute updates the row with matching rootExecution and index with the error`() {
+        val updateExecutionId = UUID.randomUUID().toString()
+        val executeStatementRequest = setUpExecuteStatementRequest(updateNextQueryWithFailedToExecuteSql(2))
+        val describeStatementRequest = setUpDescribeStatementRequest(updateExecutionId)
+        val updatedRows = 1L
+
+        whenever(redshiftDataClient.executeStatement(ArgumentMatchers.any(ExecuteStatementRequest::class.java),),).thenReturn(executeStatementResponse)
+        whenever(executeStatementResponse.id()).thenReturn(updateExecutionId)
+        whenever(redshiftDataClient.describeStatement(ArgumentMatchers.any(DescribeStatementRequest::class.java))).thenReturn(describeStatementResponse)
+        whenever(describeStatementResponse.status()).thenReturn(StatusString.FINISHED)
+        whenever(describeStatementResponse.resultRows()).thenReturn(updatedRows)
+
+        val actual = redshiftRepository.updateNextQueryWithFailedToExecute(rootExecutionId, 2, "Failed to execute query at index 2: SELECT * FROM a Error: Some network error", logger)
+
+        verify(redshiftDataClient, times(1)).executeStatement(executeStatementRequest)
+        verify(redshiftDataClient, times(1)).describeStatement(describeStatementRequest)
+        assertEquals(updatedRows, actual)
+    }
+
     private fun buildSingleRowResult() =
         listOf(
             buildRow(listOf(database, catalog, datasourceName, rootExecutionId, "\"U0VMRUNUICogRlJPTSBh\"")).plus(
@@ -171,6 +192,10 @@ class RedshiftRepositoryTest {
 
     private fun updateWithNewExecutionIdSql(): String {
         return "UPDATE datamart.admin.multiphase_query_state SET current_execution_id = '$queryExecutionId', last_update = SYSDATE WHERE root_execution_id = '${rootExecutionId}' AND index = $index"
+    }
+
+    private fun updateNextQueryWithFailedToExecuteSql(index: Long): String {
+        return "UPDATE datamart.admin.multiphase_query_state SET current_state = '$FAILED', error = 'RmFpbGVkIHRvIGV4ZWN1dGUgcXVlcnkgYXQgaW5kZXggMjogU0VMRUNUICogRlJPTSBhIEVycm9yOiBTb21lIG5ldHdvcmsgZXJyb3I=', last_update = SYSDATE WHERE root_execution_id = '${rootExecutionId}' AND index = $index"
     }
 
     private fun buildHeaderRow(): List<ColumnMetadata>  {


### PR DESCRIPTION
If there is an error thrown when attempting to call the Athena client it is for the next query to be executed and not for the current query whose state the lambda is being invoked with.
These changes address this issue and write an appropriate error marking the correct query as failed.